### PR TITLE
Corrected a missing comma in the package manifest.

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -4,7 +4,7 @@ import PackageDescription
 
 let package = Package(
     name: "KeyedCache",
-    platforms: [.macOS(.v10_10), .iOS(.v8)]
+    platforms: [.macOS(.v10_10), .iOS(.v8)],
     products: [.library(name: "KeyedCache", targets: ["KeyedCache"])],
     dependencies: [
         .package(url: "https://github.com/Balancingrock/BRUtils", from: "1.1.0")


### PR DESCRIPTION
We found this as we were indexing this package for the [Swift Package Index](https://swiftpackageindex.com) and I thought I'd just fix it!

👍